### PR TITLE
Fixed #150 - insert block from main frame, apply placeholder depth

### DIFF
--- a/js/board/BoardFrame.js
+++ b/js/board/BoardFrame.js
@@ -61,6 +61,7 @@ define([
                 vp_note_display: true,
                 viewDepthNumber: false,
                 indentCount: 4,
+                currentParentBlock : null,
                 ...this.state
             };
 
@@ -759,6 +760,10 @@ define([
                 // add to specific position
                 this.blockList.splice(position, 0, block);
             }
+            if(this.currentParentBlock){
+                this.moveBlock(position, position, this.currentParentBlock);
+                this.currentParentBlock = null;
+            }
             return block;
         }
 
@@ -807,6 +812,8 @@ define([
                     movingBlock.setGroupBlock();
                 }
                 this.reloadBlockList();
+            }else if(parentBlock){
+                this.currentParentBlock = parentBlock
             }
         }
 


### PR DESCRIPTION
![Screen Shot 2022-08-26 at 8 20 17 PM](https://user-images.githubusercontent.com/78560569/186892684-27dafdb7-133c-4a08-a191-adfd21cba92a.png)
![Aug-26-2022 20-21-48](https://user-images.githubusercontent.com/78560569/186892907-baa3b1d0-3427-4422-ab28-abe1c00228ce.gif)



* add currentParentBlock in blockFrame's state
* when main frame add block into board frame, check there is stored current parent block then move generated block to apply depth
   
   
