### PR TITLE
Fixed #233 - Using parquet and pyArrow, when R/W files

### DIFF
--- a/visualpython/data/m_library/pandasLibrary.js
+++ b/visualpython/data/m_library/pandasLibrary.js
@@ -6825,6 +6825,189 @@ define([
           },
         ]
       },
+      // ***
+      "pd_toParquet": {
+        "name": "To Parquet",
+        "library": "pandas",
+        "description": "DataFrame/Series to Parquet file",
+        "code": "${i0}.to_parquet(${path}${etc})",
+        "options": [
+          {
+            "name": "i0",
+            "label": "DataFrame",
+            "required": true,
+            "component": [
+              "data_select"
+            ],
+            "var_type": [
+              "DataFrame",
+              "Series"
+            ]
+          },
+          {
+            "name": "path",
+            "label": "File path/variable",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
+      "pd_readParquet": {
+        "name": "Read Parquet",
+        "library": "pandas",
+        "description": "Parquet to pandas object",
+        "code": "${o0} = pd.read_parquet(${i0}${etc})",
+        "options": [
+          {
+            "name": "i0",
+            "label": "File path/object",
+            "required": true,
+            "type": "text",
+            "component": [
+              "file"
+            ]
+          },
+          {
+            "name": "o0",
+            "label": "Allocate to",
+            "output": true,
+            "component": [
+              "input"
+            ],
+            "value": "vp_df"
+          },
+        ]
+      },
+      "pa_readCsv": {
+        "name": "Read Csv as pyarrow",
+        "library": "pyarrow",
+        "description": "Csv to pandas object",
+        "code": "${o0} = pa.csv.read_csv(${i0}${etc}).to_pandas()",
+        "options": [
+          {
+            "name": "i0",
+            "label": "File path/object",
+            "required": true,
+            "type": "text",
+            "component": [
+              "file"
+            ]
+          },
+          {
+            "name": "o0",
+            "label": "Allocate to",
+            "output": true,
+            "component": [
+              "input"
+            ],
+            "value": "vp_df"
+          }
+        ]
+      },
+      "pa_toCsv": {
+        "name": "To Csv as pyarrow",
+        "library": "pyarrow",
+        "description": "DataFrame/Series to csv file",
+        "code": "pa.csv.write_csv(${i0}, ${path})",
+        "options": [
+          {
+            "name": "i0",
+            "label": "DataFrame",
+            "required": true,
+            "component": [
+              "data_select"
+            ],
+            "var_type": [
+              "DataFrame",
+              "Series"
+            ]
+          },
+          {
+            "name": "path",
+            "label": "File path/variable",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
+      "pa_readJson": {
+        "name": "Read Json as pyarrow",
+        "library": "pyarrow",
+        "description": "Json to pyarrow object",
+        "code": "${o0} = pa.json.read_json(${i0}${etc}).to_pandas()",
+        "options": [
+          {
+            "name": "i0",
+            "label": "File path/object",
+            "required": true,
+            "type": "text",
+            "component": [
+              "file"
+            ]
+          },
+          {
+            "name": "o0",
+            "label": "Allocate to",
+            "output": true,
+            "component": [
+              "input"
+            ],
+            "value": "vp_df"
+          }
+        ]
+      },
+      "pa_readParquet": {
+        "name": "Read Parquet as pyarrow",
+        "library": "pyarrow",
+        "description": "Parquet to pandas object",
+        "code": "${o0} = pa.parquet.read_table(${i0}${etc}).to_pandas()",
+        "options": [
+          {
+            "name": "i0",
+            "label": "File path/object",
+            "required": true,
+            "type": "text",
+            "component": [
+              "file"
+            ]
+          },
+          {
+            "name": "o0",
+            "label": "Allocate to",
+            "output": true,
+            "component": [
+              "input"
+            ],
+            "value": "vp_df"
+          }
+        ]
+      },
+      "pa_toParquet": {
+        "name": "To Parquet as pyarrow",
+        "library": "pyarrow",
+        "description": "DataFrame/Series to Parquet file",
+        "code": "pa.parquet.write_table(${i0}, ${path})",
+        "options": [
+          {
+            "name": "i0",
+            "label": "DataFrame",
+            "required": true,
+            "component": [
+              "data_select"
+            ],
+            "var_type": [
+              "DataFrame",
+              "Series"
+            ]
+          },
+          {
+            "name": "path",
+            "label": "File path/variable",
+            "required": true,
+            "type": "text"
+          }
+        ]
+      },
     }
 
     return {

--- a/visualpython/js/com/com_Config.js
+++ b/visualpython/js/com/com_Config.js
@@ -75,7 +75,8 @@ define([
                         'import matplotlib.pyplot as plt',
                         '%matplotlib inline',
                         'import seaborn as sns',
-                        'import plotly.express as px'
+                        'import plotly.express as px',
+                        'import pyarrow as pa'
                     ],
                     'matplotlib customizing': [
                         'import matplotlib.pyplot as plt',
@@ -132,7 +133,8 @@ define([
                             'from plotly.offline import init_notebook_mode',
                             'init_notebook_mode(connected=True)'
                         ]
-                    }
+                    },
+                    { library: 'pyarrow', alias:'pa' },
                 ]
             }
 
@@ -207,6 +209,10 @@ define([
                 },
                 'statsmodels.api': {
                     code: 'import statsmodels.api as sm',
+                    type: 'package'
+                },
+                'pyarrow': {
+                    code: 'import pyarrow as pa',
                     type: 'package'
                 }
             }

--- a/visualpython/js/m_apps/Import.js
+++ b/visualpython/js/m_apps/Import.js
@@ -37,7 +37,8 @@ define([
                     'from plotly.offline import init_notebook_mode',
                     'init_notebook_mode(connected=True)'
                 ], checked: false
-            }
+            },
+            { i0: 'pyarrow', i1: 'pa', type: 'module', checked: false},
         ],
         'machine-learning': [
             { i0: 'sklearn.model_selection',  i1: 'train_test_split', type: 'function' },

--- a/visualpython/js/m_library/m_pandas/readFile.js
+++ b/visualpython/js/m_library/m_pandas/readFile.js
@@ -48,7 +48,8 @@ define([
                 'csv': 'csv',
                 'excel': 'xlsx',
                 'json': 'json',
-                'pickle': ''
+                'pickle': '',
+                'parquet': 'parquet'
             }
             this.dataPath = 'https://raw.githubusercontent.com/visualpython/visualpython/main/visualpython/data/sample_csv/';
             this.fileResultState = {
@@ -60,7 +61,8 @@ define([
                     'csv': 'pd_readCsv',
                     'excel': 'pd_readExcel',
                     'json': 'pd_readJson',
-                    'pickle': 'pd_readPickle'
+                    'pickle': 'pd_readPickle',
+                    'parquet': 'pd_readParquet'
                 },
                 selectedType: 'csv',
                 package: null

--- a/visualpython/js/m_library/m_pandas/toFile.js
+++ b/visualpython/js/m_library/m_pandas/toFile.js
@@ -48,7 +48,8 @@ define([
                 'csv': 'csv',
                 'excel': 'xlsx',
                 'json': 'json',
-                'pickle': ''
+                'pickle': '',
+                'parquet': 'parquet'
             }
             this.dataPath = 'https://raw.githubusercontent.com/visualpython/visualpython/main/visualpython/data/sample_csv/';
             this.fileResultState = {
@@ -60,7 +61,8 @@ define([
                     'csv': 'pd_toCsv',
                     'excel': 'pd_toExcel',
                     'json': 'pd_toJson',
-                    'pickle': 'pd_toPickle'
+                    'pickle': 'pd_toPickle',
+                    'parquet': 'pd_toParquet'
                 },
                 selectedType: 'csv',
                 package: null


### PR DESCRIPTION
- Add pyarrow at import app
- Add 'Use PyArrow' checkbox
- When checked 'Use PyArrow', change the generated code that used pyarrow
- Add parquet to file type

![image](https://github.com/visualpython/visualpython/assets/25974226/2def4f08-df91-4a1b-aadd-3febb2e62feb)
